### PR TITLE
Simplify navigation aesthetic and replace emoji markers

### DIFF
--- a/src/components/reactbits/GlassIcons.tsx
+++ b/src/components/reactbits/GlassIcons.tsx
@@ -2,7 +2,7 @@ import { motion } from 'framer-motion';
 import { cn } from '../../lib/cn';
 
 type GlassIconCardProps = {
-  icon: React.ReactNode;
+  badge: string;
   title: string;
   description: string;
   link?: string;
@@ -23,17 +23,15 @@ export function GlassIcons({ items, className }: GlassIconsProps) {
           whileHover={{ y: -10 }}
         >
           <div className="relative flex items-start gap-4">
-            <div className="relative flex h-14 w-14 items-center justify-center overflow-hidden rounded-2xl border border-white/10 bg-night/60">
-              <motion.span
-                aria-hidden
-                className="text-2xl"
-                initial={{ rotate: -6 }}
-                whileHover={{ rotate: 0 }}
-                transition={{ type: 'spring', stiffness: 120, damping: 15 }}
-              >
-                {item.icon}
-              </motion.span>
-            </div>
+            <motion.span
+              aria-hidden
+              className="flex h-14 w-14 items-center justify-center overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-br from-accent/15 via-transparent to-accent/5 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-accent"
+              initial={{ rotate: -8 }}
+              whileHover={{ rotate: 0 }}
+              transition={{ type: 'spring', stiffness: 120, damping: 15 }}
+            >
+              {item.badge}
+            </motion.span>
             <div className="space-y-3">
               <h3 className="font-display text-xl text-chrome">{item.title}</h3>
               <p className="text-sm text-chrome/70">{item.description}</p>

--- a/src/components/reactbits/InfiniteMenu.tsx
+++ b/src/components/reactbits/InfiniteMenu.tsx
@@ -5,7 +5,7 @@ import { cn } from '../../lib/cn';
 type InfiniteMenuItem = {
   href: string;
   label: string;
-  icon: React.ReactNode;
+  description?: string;
 };
 
 type InfiniteMenuProps = {
@@ -32,7 +32,7 @@ export function InfiniteMenu({ items, className, speed = 45 }: InfiniteMenuProps
     <div className={cn('relative overflow-hidden', className)}>
       <motion.div
         ref={base}
-        className="flex w-max items-center gap-6 whitespace-nowrap"
+        className="flex w-max items-center gap-5 whitespace-nowrap"
         style={{ transform: `translateX(-${offset}px)` }}
       >
         {repeatedItems.map((item, index) => (
@@ -40,12 +40,18 @@ export function InfiniteMenu({ items, className, speed = 45 }: InfiniteMenuProps
             whileHover={{ scale: 1.05 }}
             key={`${item.href}-${index}`}
             href={item.href}
-            className="flex items-center gap-3 rounded-full border border-white/10 bg-night/60 px-4 py-2 text-sm text-chrome/80 transition-colors hover:border-accent hover:text-accent"
+            className="flex items-center gap-3 rounded-full border border-white/10 bg-night/60 px-5 py-2 text-left text-sm text-chrome/80 transition-colors hover:border-accent hover:text-accent"
           >
-            <span className="text-lg" aria-hidden>
-              {item.icon}
+            <span
+              aria-hidden
+              className="relative flex h-8 w-8 items-center justify-center overflow-hidden rounded-full border border-white/10 bg-gradient-to-br from-accent/20 via-transparent to-accent/10"
+            >
+              <span className="h-1.5 w-1.5 rounded-full bg-accent shadow-[0_0_12px_rgba(123,223,242,0.55)]" />
             </span>
-            <span>{item.label}</span>
+            <span className="flex flex-col leading-snug">
+              <span className="text-[0.65rem] uppercase tracking-[0.4em] text-chrome/60">{item.label}</span>
+              {item.description && <span className="text-xs text-chrome/50">{item.description}</span>}
+            </span>
           </motion.a>
         ))}
       </motion.div>

--- a/src/components/reactbits/Stepper.tsx
+++ b/src/components/reactbits/Stepper.tsx
@@ -5,7 +5,7 @@ type Step = {
   id: string;
   title: string;
   description: string;
-  icon: React.ReactNode;
+  phase?: string;
 };
 
 type StepperProps = {
@@ -31,21 +31,26 @@ export function Stepper({ steps, currentIndex = 0, onStepChange, className }: St
             viewport={{ once: true, amount: 0.4 }}
           >
             <div className="relative flex h-12 w-12 items-center justify-center">
-              <div className="absolute inset-0 rounded-full border border-accent/30 bg-night/70" />
-              <motion.div
+              <div className={cn('absolute inset-0 rounded-full border', isActive ? 'border-accent/40' : 'border-white/10')} />
+              <motion.span
                 className={cn(
-                  'relative flex h-10 w-10 items-center justify-center rounded-full border text-xl text-accent',
-                  isActive ? 'border-accent bg-accent/15 text-accent' : 'border-white/10 text-chrome/40'
+                  'relative flex h-10 w-10 items-center justify-center rounded-full bg-night/70 text-xs font-medium uppercase tracking-[0.35em]',
+                  isActive ? 'text-accent' : 'text-chrome/50'
                 )}
                 animate={isActive ? { scale: 1.05 } : { scale: 1 }}
               >
-                <span aria-hidden>{step.icon}</span>
-              </motion.div>
+                {String(index + 1).padStart(2, '0')}
+              </motion.span>
             </div>
             <div className="space-y-2">
-              <div className="flex items-center gap-3">
+              <div className="flex flex-wrap items-center gap-3">
                 <span className="font-display text-lg text-chrome">{step.title}</span>
-                <span className="text-xs uppercase tracking-[0.35em] text-accent/60">Étape {index + 1}</span>
+                {step.phase && (
+                  <span className="rounded-full bg-accent/15 px-3 py-1 text-[0.65rem] uppercase tracking-[0.35em] text-accent">
+                    {step.phase}
+                  </span>
+                )}
+                <span className="text-[0.65rem] uppercase tracking-[0.35em] text-accent/60">Étape {String(index + 1).padStart(2, '0')}</span>
               </div>
               <p className="max-w-xl text-sm text-chrome/70">{step.description}</p>
             </div>

--- a/src/data/page.ts
+++ b/src/data/page.ts
@@ -1,15 +1,14 @@
 export const navLinks = [
-  { href: '#hero', label: 'Immersion', icon: '🌌' },
-  { href: '#narrative-nav', label: 'Navigation', icon: '🧭' },
-  { href: '#arguments', label: 'Pourquoi nous', icon: '⚡️' },
-  { href: '#showroom', label: 'Showroom', icon: '🚗' },
-  { href: '#gallery', label: 'Galaxie', icon: '🪐' },
-  { href: '#processus', label: 'Process', icon: '🧬' },
-  { href: '#technos', label: 'Technos', icon: '🛠️' },
-  { href: '#temoignages', label: 'Avis', icon: '💬' },
-  { href: '#cta', label: 'Action', icon: '🚀' },
-  { href: '#blog', label: 'Ressources', icon: '📚' },
-  { href: '#footer', label: 'Contact', icon: '📞' },
+  { href: '#hero', label: 'Immersion', description: 'Introduction' },
+  { href: '#arguments', label: 'Preuves', description: 'Pourquoi nous' },
+  { href: '#showroom', label: 'Showroom', description: 'Expériences' },
+  { href: '#gallery', label: 'Galaxie', description: 'Laboratoire' },
+  { href: '#processus', label: 'Process', description: 'Méthode' },
+  { href: '#technos', label: 'Technos', description: 'Stack' },
+  { href: '#temoignages', label: 'Avis', description: 'Clients' },
+  { href: '#cta', label: 'Action', description: 'Prise de contact' },
+  { href: '#blog', label: 'Ressources', description: 'Articles' },
+  { href: '#footer', label: 'Contact', description: 'Coordonnées' },
 ];
 
 export const heroContent = {
@@ -25,37 +24,37 @@ export const uspList = [
   {
     title: 'Narrative Flow',
     description: 'Orchestration serpentine de contenu pour ancrer la compréhension et réduire le churn exploratoire.',
-    icon: '🌀',
+    category: 'Stratégie',
   },
   {
     title: 'Cinematic Layers',
     description: 'Plans superposés, parallaxe contrôlée et focus dynamique pour capter l’attention dès la première seconde.',
-    icon: '🎬',
+    category: 'Scénographie',
   },
   {
     title: 'Hyper-personnalisation',
     description: 'Cartographie du parcours utilisateur alimentée par la data pour déclencher les bons signaux au bon moment.',
-    icon: '🧠',
+    category: 'Data',
   },
   {
     title: 'Conversion tactile',
     description: 'Gestuelles naturelles, drags contrôlés et feedback haptiques visuels pour transformer l’engagement en action.',
-    icon: '🤲',
+    category: 'Interaction',
   },
   {
     title: 'Accessibilité renforcée',
     description: 'Contraste élevé, commandes vocales optionnelles et logique DOM linéaire pour tous les visiteurs.',
-    icon: '♿️',
+    category: 'Accessibilité',
   },
   {
     title: 'Ops et performance',
     description: 'Chargements paresseux, paquets fractionnés et animations décélérées sur mobile pour garder le site vif.',
-    icon: '⚙️',
+    category: 'Performance',
   },
   {
     title: 'Sécurité intégrée',
     description: 'Audit continu, stockage chiffré et surveillance proactive pour vos données critiques.',
-    icon: '🛡️',
+    category: 'Sécurité',
   },
 ];
 
@@ -135,57 +134,57 @@ export const processSteps = [
     id: 'immersion',
     title: 'Immersion stratégique',
     description: 'Workshops avec vos équipes pour tracer la sinusoïde narrative et définir les jalons émotionnels.',
-    icon: '🔭',
+    phase: 'Cartographier',
   },
   {
     id: 'prototypage',
     title: 'Prototypage multi-sens',
     description: 'Wireflows organiques, maquettes motion et prototypes tactiles prêts pour tests.',
-    icon: '🧪',
+    phase: 'Prototyper',
   },
   {
     id: 'production',
     title: 'Production cinétique',
     description: 'Déploiement React + WebGL, intégration des composants ReactBits optimisés, QA multi-device.',
-    icon: '🛠️',
+    phase: 'Produire',
   },
   {
     id: 'lancement',
     title: 'Lancement orbital',
     description: 'Monitoring en direct, outils de mesure intégrés et tuning des animations post-lancement.',
-    icon: '🚀',
+    phase: 'Déployer',
   },
   {
     id: 'growth',
     title: 'Growth continu',
     description: 'Analyse data-driven, A/B tests cinétiques et roadmap d’amélioration perpétuelle.',
-    icon: '📈',
+    phase: 'Optimiser',
   },
 ];
 
 export const technoCards = [
   {
-    icon: '⚛️',
     title: 'React 18 + Server Islands',
     description: 'Hydratation ciblée et streaming pour des pages ultra-rapides, même avec des animations riches.',
+    badge: 'Front-end',
     link: 'https://react.dev/',
   },
   {
-    icon: '💠',
     title: 'Framer Motion 11',
     description: 'Timeline avancée, gestures fluides et orchestration multi-couches sans compromis.',
+    badge: 'Motion',
     link: 'https://www.framer.com/motion/',
   },
   {
-    icon: '🌫️',
     title: 'Tailwind CSS 3',
     description: 'Design system organique et tokens modulables pour sculpter chaque courbe.',
+    badge: 'Design',
     link: 'https://tailwindcss.com/',
   },
   {
-    icon: '🛰️',
     title: 'ReactBits',
     description: 'Bibliothèque de micro-interactions premium, adaptée pour l’ultra expressivité.',
+    badge: 'Interactions',
     link: 'https://github.com/',
   },
 ];

--- a/src/sections/ArgumentsSection.tsx
+++ b/src/sections/ArgumentsSection.tsx
@@ -5,36 +5,34 @@ export function ArgumentsSection() {
   return (
     <section
       id="arguments"
-      className="relative mx-auto mt-40 max-w-6xl overflow-hidden rounded-[3.5rem] border border-white/5 bg-[#11151f] px-6 py-24 shadow-subtle"
+      className="relative mx-auto mt-32 max-w-6xl overflow-hidden rounded-[3rem] border border-white/10 bg-night/80 px-6 py-24 shadow-subtle"
     >
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(123,223,242,0.25),transparent_55%),radial-gradient(circle_at_bottom_right,rgba(240,157,81,0.2),transparent_60%)]" />
       <div className="relative z-10">
         <header className="mx-auto max-w-3xl text-center">
           <h2 className="font-display text-3xl text-chrome sm:text-4xl">Les bénéfices serpentins</h2>
-          <p className="mt-4 text-base text-chrome/70">
-            Chaque argument s’inscrit dans une trajectoire en S pour guider l’œil et le parcours de lecture.
-          </p>
+          <p className="mt-4 text-base text-chrome/70">Chaque argument s’aligne sur une ligne claire et lisible.</p>
         </header>
         <AnimatedList
           className="mt-16"
           items={uspList}
           renderItem={(usp, index) => (
             <article
-              className={`group grid gap-8 rounded-[2.5rem] border border-white/5 bg-night/60 p-6 backdrop-blur md:grid-cols-2 md:items-center ${index % 2 === 0 ? 'md:[clip-path:polygon(0%_0%,92%_0,100%_15%,100%_100%,8%_100%,0%_85%)]' : 'md:[clip-path:polygon(0%_15%,8%_0%,100%_0%,100%_85%,92%_100%,0%_100%)]'}`}
+              className="group grid gap-8 rounded-[2.5rem] border border-white/10 bg-night/70 p-8 backdrop-blur md:grid-cols-2 md:items-center"
             >
-              <div className={`space-y-4 ${index % 2 === 0 ? 'md:order-1' : 'md:order-2'}`}>
-                <div className="inline-flex h-12 w-12 items-center justify-center rounded-full border border-accent/40 bg-steel/80 text-xl">
-                  <span aria-hidden>{usp.icon}</span>
+              <div className={`space-y-6 ${index % 2 === 0 ? 'md:order-1' : 'md:order-2'}`}>
+                <div className="flex items-center gap-4 text-xs uppercase tracking-[0.35em] text-chrome/50">
+                  <span className="rounded-full bg-accent/15 px-4 py-1 text-accent">{String(index + 1).padStart(2, '0')}</span>
+                  {usp.category && <span>{usp.category}</span>}
                 </div>
                 <h3 className="font-display text-2xl text-chrome">{usp.title}</h3>
                 <p className="text-sm text-chrome/70">{usp.description}</p>
               </div>
               <div className={`relative ${index % 2 === 0 ? 'md:order-2' : 'md:order-1'}`}>
-                <div className="relative h-56 overflow-hidden rounded-[2.5rem] border border-white/10 bg-gradient-to-br from-steel/70 to-night/40">
-                  <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(123,223,242,0.25),transparent_65%)]" />
-                  <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom,rgba(240,157,81,0.25),transparent_70%)]" />
-                  <p className="relative p-6 text-sm text-chrome/60">
-                    Micro-motions au survol, icônes dynamiques et transitions diagonales pour un scan rapide.
+                <div className="relative h-56 overflow-hidden rounded-[2.25rem] border border-white/10 bg-gradient-to-br from-steel/60 via-night/60 to-night/40">
+                  <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(123,223,242,0.18),transparent_60%)]" />
+                  <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom_right,rgba(240,157,81,0.15),transparent_70%)]" />
+                  <p className="relative flex h-full items-center p-6 text-sm text-chrome/60">
+                    Mise en avant progressive du contenu, structure linéaire et transitions fluides pour guider le regard sans surcharge.
                   </p>
                 </div>
               </div>

--- a/src/sections/NavigationCrown.tsx
+++ b/src/sections/NavigationCrown.tsx
@@ -24,9 +24,7 @@ export function NavigationCrown() {
             LuxDrive 360
           </a>
           <div className="hidden flex-1 md:block">
-            <InfiniteMenu
-              items={navLinks.map((link) => ({ href: link.href, label: link.label, icon: <span>{link.icon}</span> }))}
-            />
+            <InfiniteMenu items={navLinks.map((link) => ({ href: link.href, label: link.label, description: link.description }))} />
           </div>
           <div className="md:hidden">
             <button
@@ -43,24 +41,24 @@ export function NavigationCrown() {
           {isOpen && (
             <motion.div
               id="menu-radial"
-              initial={{ opacity: 0, scale: 0.8 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.8 }}
+              initial={{ opacity: 0, y: -8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -8 }}
               className="md:hidden"
             >
-              <div className="absolute left-1/2 top-full z-50 mt-4 h-60 w-60 -translate-x-1/2 rounded-full border border-white/10 bg-night/80 p-6 text-sm backdrop-blur">
-                <ul className="grid h-full w-full grid-cols-2 place-items-center gap-4">
+              <div className="absolute left-0 right-0 top-full z-50 mt-4 rounded-3xl border border-white/10 bg-night/90 p-5 shadow-subtle backdrop-blur">
+                <ul className="flex flex-col gap-3 text-sm">
                   {navLinks.map((link) => (
                     <li key={link.href}>
                       <a
                         href={link.href}
-                        className="flex h-20 w-20 flex-col items-center justify-center gap-1 rounded-full border border-white/10 bg-steel/70 text-center text-[0.65rem] uppercase tracking-[0.35em] text-chrome/80"
+                        className="flex items-center justify-between gap-4 rounded-2xl border border-transparent px-4 py-3 text-chrome/80 transition-colors hover:border-accent/40 hover:text-chrome"
                         onClick={() => setIsOpen(false)}
                       >
-                        <span aria-hidden className="text-base">
-                          {link.icon}
-                        </span>
-                        {link.label}
+                        <span className="text-sm font-medium">{link.label}</span>
+                        {link.description && (
+                          <span className="text-[0.65rem] uppercase tracking-[0.35em] text-chrome/50">{link.description}</span>
+                        )}
                       </a>
                     </li>
                   ))}

--- a/src/sections/ProcessSection.tsx
+++ b/src/sections/ProcessSection.tsx
@@ -11,9 +11,7 @@ export function ProcessSection() {
         <div className="flex flex-col gap-16 lg:flex-row">
           <div className="flex-1">
             <h2 className="font-display text-3xl text-chrome sm:text-4xl">Process sinusoïdal</h2>
-            <p className="mt-4 text-base text-chrome/70">
-              Une timeline ondulée qui révèle chaque étape au scroll, jalons positionnés sur les crêtes.
-            </p>
+            <p className="mt-4 text-base text-chrome/70">Une colonne claire pour suivre chaque étape sans se perdre.</p>
             <div className="mt-10 hidden lg:block">
               <Stepper steps={processSteps} currentIndex={current} onStepChange={setCurrent} />
             </div>
@@ -30,13 +28,21 @@ export function ProcessSection() {
                     onFocus={() => setCurrent(index)}
                     tabIndex={0}
                   >
-                    <div className="flex items-center gap-4">
-                      <div className="flex h-12 w-12 items-center justify-center rounded-full border border-accent/40 bg-night/60 text-xl">
-                        <span aria-hidden>{step.icon}</span>
+                    <div className="flex items-start gap-4">
+                      <div className="flex h-12 w-12 items-center justify-center rounded-full border border-accent/30 bg-night/60 text-xs uppercase tracking-[0.35em] text-accent">
+                        {String(index + 1).padStart(2, '0')}
                       </div>
-                      <div>
+                      <div className="space-y-2">
+                        <div className="flex flex-wrap items-center gap-3">
+                          {step.phase && (
+                            <span className="rounded-full bg-accent/15 px-3 py-1 text-[0.65rem] uppercase tracking-[0.35em] text-accent">
+                              {step.phase}
+                            </span>
+                          )}
+                          <span className="text-[0.65rem] uppercase tracking-[0.35em] text-chrome/50">Étape {String(index + 1).padStart(2, '0')}</span>
+                        </div>
                         <h3 className="font-display text-xl text-chrome">{step.title}</h3>
-                        <p className="mt-1 text-sm text-chrome/60">{step.description}</p>
+                        <p className="text-sm text-chrome/60">{step.description}</p>
                       </div>
                     </div>
                   </article>


### PR DESCRIPTION
## Summary
- remove emoji-based navigation and data markers in favor of typographic badges and descriptions
- refresh the arguments, process, and technology sections with clearer spacing and numbered accents
- update shared components to support the new badge-driven styling across sections

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6900b0fc7e6c832e95b1d112daec2321